### PR TITLE
Implement Zustand store simplification

### DIFF
--- a/components/forms/issuer-details-form.tsx
+++ b/components/forms/issuer-details-form.tsx
@@ -20,13 +20,15 @@ import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { issuerDetailsSchema, type IssuerDetailsData } from '@/schemas';
 import { useWizardStepForm } from '@/hooks/use-wizard-step-form';
+import { useWizardStore } from '@/store/wizard-store';
+
 interface IssuerDetailsFormProps {
   initialData?: Partial<IssuerDetailsData>;
   onSubmit?: (data: IssuerDetailsData) => void;
 }
 
 export function IssuerDetailsForm({ initialData, onSubmit }: IssuerDetailsFormProps) {
-  const { updateFormData, formData, markValid } = useWizardStore();
+  const { updateFormData, formData } = useWizardStore();
   const [validFields, setValidFields] = useState<Set<string>>(new Set());
   
   const form = useForm<IssuerDetailsData>({
@@ -70,15 +72,6 @@ export function IssuerDetailsForm({ initialData, onSubmit }: IssuerDetailsFormPr
       return prevValidFields;
     });
   }, [JSON.stringify(watchedValues)]);
-
-  // Update wizard store validation state - debounced to avoid excessive calls
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      markValid('issuer-details', form.formState.isValid);
-    }, 100);
-    
-    return () => clearTimeout(timeoutId);
-  }, [form.formState.isValid, markValid]);
 
   // Save form data to store on change
   useEffect(() => {

--- a/components/forms/recipient-details-form.tsx
+++ b/components/forms/recipient-details-form.tsx
@@ -19,7 +19,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { recipientDetailsSchema, type RecipientDetailsData } from '@/schemas';
-import { useWizardStepForm } from '@/hooks/use-wizard-step-form';
+import { useWizardStore } from '@/store/wizard-store';
+import { useStepper } from '@/components/wizard/stepper-layout';
+
 interface RecipientDetailsFormProps {
   initialData?: Partial<RecipientDetailsData>;
   onSubmit?: (data: RecipientDetailsData) => void;
@@ -42,7 +44,8 @@ const FieldIcon = ({ isValid }: { isValid: boolean }) => (
 );
 
 export function RecipientDetailsForm({ initialData, onSubmit }: RecipientDetailsFormProps) {
-  const { updateFormData, formData, markValid } = useWizardStore();
+  const { updateFormData, formData } = useWizardStore();
+  const stepper = useStepper();
   const [validFields, setValidFields] = useState<Set<string>>(new Set());
   
   const form = useForm<RecipientDetailsData>({
@@ -85,15 +88,6 @@ export function RecipientDetailsForm({ initialData, onSubmit }: RecipientDetails
       return prevValidFields;
     });
   }, [JSON.stringify(watchedValues)]);
-
-  // Update wizard store validation state - debounced to avoid excessive calls
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      markValid('recipient-details', form.formState.isValid);
-    }, 100);
-    
-    return () => clearTimeout(timeoutId);
-  }, [form.formState.isValid, markValid]);
 
   // Save form data to store on change
   useEffect(() => {

--- a/docs/stepperize-migration/task-05-summary.md
+++ b/docs/stepperize-migration/task-05-summary.md
@@ -1,0 +1,71 @@
+# Task 05 - Zustand Store Simplification Summary
+
+## Overview
+Successfully simplified the Zustand store by removing all navigation-related fields and methods, keeping only form data persistence functionality. The store is now focused solely on managing form data, while navigation is handled entirely by Stepperize.
+
+## Changes Made
+
+### 1. Store Simplification (`store/wizard-store.ts`)
+- **Removed navigation state fields:**
+  - `currentStep`, `completedSteps`, `currentId`, `completed`, `validMap`
+  
+- **Removed navigation methods:**
+  - `goTo()`, `next()`, `prev()`, `markValid()`, `resetStepper()`
+  - `setCurrentStep()`, `markStepCompleted()`, `markStepIncomplete()`
+  - `canNavigateToStep()`, `getVisibleSteps()`, `getAccessibleSteps()`
+  - `isStepVisible()`, `isStepAccessible()`, `canNavigateToStepId()`
+
+- **Kept only form-related functionality:**
+  - `formData`, `validationErrors`, `isDirty`, `lastSavedAt`
+  - `updateFormData()`, `setValidationErrors()`, `clearValidationErrors()`
+  - `setIsDirty()`, `saveDraft()`, `resetWizard()`
+
+- **Simplified persistence:**
+  - Now only persists `formData` and `lastSavedAt`
+  - Removed complex rehydration logic for Sets
+
+### 2. Component Updates
+
+#### `app/(wizard)/layout.tsx`
+- Removed all references to store navigation fields
+- Now uses `useStepper()` hook from Stepperize for:
+  - Getting current step: `stepper.current`
+  - Navigation: `methods.goTo()`, `methods.next()`, `methods.prev()`
+  - Visibility checks: `methods.utils.isStepVisible()`
+  - Accessibility checks: `methods.utils.isStepAccessible()`
+  - Getting metadata: `metadata.completed`, `metadata.validMap`
+
+#### `app/(wizard)/wizard/page.tsx`
+- Removed `markValid` usage
+- Now uses `stepper.utils.markValid()` for validation
+- Uses `stepper.current.id` to get current step
+- Uses `stepper.utils.isStepVisible()` and `stepper.utils.isStepAccessible()`
+
+#### Form Components
+- `components/forms/recipient-details-form.tsx`: Removed `markValid` import and usage
+- `components/forms/issuer-details-form.tsx`: Removed `markValid` import and usage
+- Both forms no longer update validation state in the store
+
+### 3. Benefits Achieved
+
+1. **Cleaner separation of concerns**: Store now only handles data persistence
+2. **Reduced complexity**: Removed ~260 lines of navigation logic
+3. **No duplicate state**: Navigation state lives only in Stepperize
+4. **Simpler persistence**: No more complex Set serialization/deserialization
+5. **Better maintainability**: Single source of truth for navigation
+
+## Testing Recommendations
+
+1. **Data persistence**: Verify form data still persists across page refreshes
+2. **Navigation**: Ensure all navigation still works through Stepperize
+3. **Validation**: Check that form validation still functions correctly
+4. **Draft saving**: Confirm draft save functionality still works
+
+## Next Steps
+
+With the store simplified, the next task (Task 06) will focus on enhancing persistence metadata to ensure proper data migration and versioning.
+
+## Branch Information
+- Branch: `feat/migration-task-05-zustand-store`
+- Commits: 1 commit with comprehensive changes
+- Ready for PR and merge


### PR DESCRIPTION
The Zustand store (`store/wizard-store.ts`) was significantly simplified by removing all navigation-related state and methods, such as `currentId`, `completed`, `validMap`, `goTo`, `next`, `prev`, `markValid`, and `resetStepper`. The store now solely manages `formData` and `lastSavedAt`, simplifying its persistence logic.

This change shifts navigation responsibility entirely to the Stepperize library. Consequently:
*   `app/(wizard)/layout.tsx` was updated to use the `useStepper()` hook for all navigation, step visibility, and accessibility logic, replacing direct calls to the wizard store's navigation methods.
*   `app/(wizard)/wizard/page.tsx` now retrieves the current step ID and uses visibility/accessibility checks from `useStepper()`, and calls `stepper.utils.markValid()` for step validation.
*   Form components like `components/forms/issuer-details-form.tsx` and `components/forms/recipient-details-form.tsx` no longer import or use `markValid` from the wizard store, as step validation state is managed by Stepperize.

This refactoring achieves a cleaner separation of concerns, reduces the complexity of the Zustand store, and establishes Stepperize as the single source of truth for wizard navigation.